### PR TITLE
Make job config file configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 tpv_mutable_dir: "{{ galaxy_mutable_data_dir }}/total_perspective_vortex"
 tpv_config_dir_name: TPV_DO_NOT_TOUCH
 tpv_config_dir: "{{ galaxy_config_dir }}/{{ tpv_config_dir_name }}"
+galaxy_job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"

--- a/templates/tpv-lint-and-copy.sh.j2
+++ b/templates/tpv-lint-and-copy.sh.j2
@@ -6,20 +6,20 @@ VENV="{{ galaxy_venv_dir }}"
 TPV_MUTABLE_DIR="{{ tpv_mutable_dir }}"
 TPV_DIR="{{ tpv_config_dir }}"
 TPV_DIR_NAME="{{ tpv_config_dir_name }}"
-GALAXY_CONF_DIR="{{ galaxy_config_dir }}"
+JOB_CONFIG_FILE="{{ galaxy_job_config_file }}"
 
 . $VENV/bin/activate
 
 for f in "$TPV_MUTABLE_DIR"/*.yml; do
         FNAME=$(basename "$f")
         if PYTHONPATH=$PYTHONPATH tpv lint "$f"; then
-                echo "lint successful, checking job_conf..."
-                if grep -q "$TPV_DIR_NAME/$FNAME" "$GALAXY_CONF_DIR/job_conf.yml"; then
-                        echo "$FNAME is present in job_conf, copying..."
+                echo "lint successful, checking job configuration..."
+                if grep -q "$TPV_DIR_NAME/$FNAME" "$JOB_CONFIG_FILE"; then
+                        echo "$FNAME is present in job configuration, copying..."
                         [[ $(type -t cp) == "alias" ]] && unalias cp
                         cp -bu "$f" "$TPV_DIR/$FNAME"
                 else
-                        echo "$FNAME is not present in job_conf, exiting..."
+                        echo "$FNAME is not present in job configuration, exiting..."
                         exit 3 && true
                 fi
         else


### PR DESCRIPTION
In the last iteration of the admin training the job config is defined inline in galaxy.yml, so the role was failing there.
This way we can just set job_config_file to galaxy.yml