### PR TITLE
Drop dependency on galaxyproject.galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,3 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-
-dependencies:
-  - role: galaxyproject.galaxy


### PR DESCRIPTION
If you are already running galaxyproject.galaxy in your playbook, this role dep causes it to be run a second time.