### PR TITLE
Always overwrite existing TPV files

### DIFF
--- a/templates/tpv-lint-and-copy.sh.j2
+++ b/templates/tpv-lint-and-copy.sh.j2
@@ -17,7 +17,7 @@ for f in "$TPV_MUTABLE_DIR"/*.yml; do
                 if grep -q "$TPV_DIR_NAME/$FNAME" "$JOB_CONFIG_FILE"; then
                         echo "$FNAME is present in job configuration, copying..."
                         [[ $(type -t cp) == "alias" ]] && unalias cp
-                        cp -bu "$f" "$TPV_DIR/$FNAME" {% if tpv_privsep %}&& chown root:{{ __galaxy_user_group }} "$TPV_DIR/$FNAME" {% endif %}
+                        cp -b "$f" "$TPV_DIR/$FNAME" {% if tpv_privsep %}&& chown root:{{ __galaxy_user_group }} "$TPV_DIR/$FNAME" {% endif %}
 
                 else
                         echo "$FNAME is not present in job configuration, exiting..."


### PR DESCRIPTION
I think maybe it was not the best design decision to copy the files only if they are older than the existing ones. Even though Ansible has limitations and the server will never match the playbook perfectly (e.g. systemd services removed from Ansible that remain on the server), I think what is on the server should be as consistent as possible with [usegalaxy-eu/infrastructure-playbook](https://github.com/usegalaxy-eu/infrastructure-playbook).

We were lucky this time and the TPV climate strike rule did not fail because of that but because of usegalaxy-eu/infrastructure-playbook#904. Nevertheless, I am sure the day will come when somebody pushes something critical to GitHub and somebody else modifies the same file directly on the server later on that same day, causing the file not to be updated.