### PR TITLE
Use Ansible to stage, lint, and deploy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
+---
+
+# path in playbook, can be templates (suffix with .j2) or regular files
+tpv_configs: []
+
+# this is the path this role will read staged (by galaxyproject.galaxy) TPV configs from
 tpv_mutable_dir: "{{ galaxy_mutable_data_dir }}/total_perspective_vortex"
+
+# this is the path where this role copies TPV configs to and Galaxy reads TPV configs from
 tpv_config_dir_name: TPV_DO_NOT_TOUCH
 tpv_config_dir: "{{ galaxy_config_dir }}/{{ tpv_config_dir_name }}"
+
 galaxy_job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"
 tpv_privsep: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,65 @@
 ---
+
 - name: Create TPV mutable dir
   ansible.builtin.file:
     state: directory
     path: "{{ tpv_mutable_dir }}"
     mode: 0755
 
-- name: Copy TPV lint-and-copy-script
-  ansible.builtin.template:
-    src: tpv-lint-and-copy.sh.j2
-    dest: "{{ tpv_mutable_dir }}/tpv-lint-and-copy.sh"
-    owner: root
-    group: root
-    mode: 0750
+- name: Stage TPV configs (copy)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ tpv_mutable_dir }}/{{ item | basename }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: not item.endswith(".j2")
 
-- name: Execute TPV lint-and-copy-script
+- name: Stage TPV configs (template)
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ tpv_mutable_dir }}/{{ item | basename | splitext | first }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: item.endswith(".j2")
+
+- name: Verify that TPV configs appear in Galaxy job configuration
+  ansible.builtin.lineinfile:
+    path: "{{ galaxy_job_config_file }}"
+    regexp: '^(\s+-\s*["'']?{{ tpv_config_dir }}/{{ item.endswith(".j2") | ternary(item | basename | splitext | first, item | basename) }}["'']?\s*)$'
+    state: absent
+  check_mode: true
+  diff: false
+  loop: "{{ tpv_configs }}"
+  register: __tpv_config_is_configured
+  changed_when: false
+  failed_when: not __tpv_config_is_configured.found
+
+- name: Run TPV lint
   ansible.builtin.command:
-    cmd: "{{ tpv_mutable_dir }}/tpv-lint-and-copy.sh"
+    cmd: "{{ galaxy_venv_dir }}/bin/tpv lint {{ tpv_mutable_dir }}/{{ item.endswith('.j2') | ternary(item | basename | splitext | first, item | basename) }}"
+  environment:
+    PYTHONPATH: "{{ galaxy_server_dir }}/lib"
+  loop: "{{ tpv_configs }}"
+  changed_when: false
+
+- name: Create TPV config dir
+  ansible.builtin.file:
+    state: directory
+    path: "{{ tpv_config_dir }}"
+    mode: 0755
+
+- name: Deploy TPV configs (copy)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ tpv_config_dir }}/{{ item | basename }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: not item.endswith(".j2")
+
+- name: Stage TPV configs (template)
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ tpv_config_dir }}/{{ item | basename | splitext | first }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: item.endswith(".j2")


### PR DESCRIPTION
Request for comment, I am not sure if everyone will like this direction or not and I'm happy to be told no. :smile: 

Two big changes here:

1. You'd deploy the TPV configs from this role rather than `galaxy_config_(files|templates)` in `galaxyproject.galaxy`
2. Implement most of the bash script functionality directly as Ansible tasks.

There is a bit of a catch-22 (although the same problem occurs with the current method) since the job conf references TPV configs that won't be deployed until after `galaxyproject.galaxy` runs. But as long as this role and `galaxyproject.galaxy` are in the same play, I think the handlers should run after *everything* is fully deployed.

`tpv_config_files` is a list of paths to TPV config files in your playbook. Any path that ends in `.j2` is assumed to be a template, everything else is a file. These are `basename`d (and `.j2` is stripped as needed) and deployed first to the staging (`tpv_mutable_dir`) path, linted, checked for reference in `job_conf.yml`, and then deployed to `tpv_config_dir` if the play has not failed by that point.