### PR TITLE
add dry-run functionality to tpv linting role

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See [defaults/main](./default/main.yml) or galaxy's [default/main](https://githu
 | `tpv_dry_run_all_tools` | `false` | If `false` (default), only runs dry-run for tools that are new in the staged configs compared to what is deployed. If `true`, runs dry-run for every non-abstract tool in all local and remote configs. |
 | `tpv_dry_run_remote_configs` | `[]` | List of remote TPV config URLs (e.g. from `tpv-shared-database`) to include when `tpv_dry_run_all_tools: true`. |
 | `tpv_dry_run_user` | `""` | Email of the Galaxy user to impersonate during `tpv dry-run`. Required if your TPV config has a `requires_login` rule (i.e. `if: not user`). |
+| `tpv_dry_run_ignore_errors` | `true` | If `true` (default), dry-run failures are non-fatal and the rest of the role continues. Set to `false` to abort on any dry-run failure. |
 
 ## Playbook Example
 Include role in your Galaxyserver Playbook **after** the galaxyproject.galaxy role (the dirs have to exist already)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ With this script, TPV in Galaxy's job handlers can't break anymore. Which would 
 
 ## Role Variables
 See [defaults/main](./default/main.yml) or galaxy's [default/main](https://github.com/galaxyproject/ansible-galaxy/blob/main/defaults/main.yml)
+
+| Variable | Default | Description |
+|---|---|---|
+| `tpv_configs` | `[]` | List of TPV config file paths in the playbook to deploy (can be templates with `.j2` suffix) |
+| `tpv_mutable_dir` | `{{ galaxy_mutable_data_dir }}/total_perspective_vortex` | Directory where TPV config files are staged |
+| `tpv_config_dir_name` | `TPV_DO_NOT_TOUCH` | Name of the deployed TPV config directory |
+| `tpv_config_dir` | `{{ galaxy_config_dir }}/{{ tpv_config_dir_name }}` | Full path to the deployed TPV config directory |
+| `galaxy_job_config_file` | `{{ galaxy_config_dir }}/job_conf.yml` | Path to Galaxy's job configuration file |
+| `tpv_privsep` | `false` | If `true`, sets ownership of copied files to `root:<galaxy_user_group>` |
+| `tpv_dry_run` | `false` | If `true`, runs `tpv dry-run` before copying. Aborts if any dry-run fails. Requires `galaxy_job_config` to be set (the job config dict), which is written to a temp file since `tpv dry-run --job-conf` requires a standalone file with `runners:` at the root. |
+| `tpv_dry_run_all_tools` | `false` | If `false` (default), only runs dry-run for tools that are new in the staged configs compared to what is deployed. If `true`, runs dry-run for every non-abstract tool in all local and remote configs. |
+| `tpv_dry_run_remote_configs` | `[]` | List of remote TPV config URLs (e.g. from `tpv-shared-database`) to include when `tpv_dry_run_all_tools: true`. |
+| `tpv_dry_run_user` | `""` | Email of the Galaxy user to impersonate during `tpv dry-run`. Required if your TPV config has a `requires_login` rule (i.e. `if: not user`). |
+
 ## Playbook Example
 Include role in your Galaxyserver Playbook **after** the galaxyproject.galaxy role (the dirs have to exist already)
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
+---
+
+# path in playbook, can be templates (suffix with .j2) or regular files
+tpv_configs: []
+
+# this is the path this role will read staged (by galaxyproject.galaxy) TPV configs from
 tpv_mutable_dir: "{{ galaxy_mutable_data_dir }}/total_perspective_vortex"
+
+# this is the path where this role copies TPV configs to and Galaxy reads TPV configs from
 tpv_config_dir_name: TPV_DO_NOT_TOUCH
 tpv_config_dir: "{{ galaxy_config_dir }}/{{ tpv_config_dir_name }}"
+
 galaxy_job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"
 tpv_privsep: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,7 @@ tpv_config_dir: "{{ galaxy_config_dir }}/{{ tpv_config_dir_name }}"
 
 galaxy_job_config_file: "{{ galaxy_config_dir }}/job_conf.yml"
 tpv_privsep: false
+tpv_dry_run: false
+tpv_dry_run_all_tools: false
+tpv_dry_run_remote_configs: []
+tpv_dry_run_user: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ tpv_dry_run: false
 tpv_dry_run_all_tools: false
 tpv_dry_run_remote_configs: []
 tpv_dry_run_user: ""
+tpv_dry_run_ignore_errors: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,65 @@
 ---
+
 - name: Create TPV mutable dir
   ansible.builtin.file:
     state: directory
     path: "{{ tpv_mutable_dir }}"
     mode: 0755
 
-- name: Copy TPV lint-and-copy-script
-  ansible.builtin.template:
-    src: tpv-lint-and-copy.sh.j2
-    dest: "{{ tpv_mutable_dir }}/tpv-lint-and-copy.sh"
-    owner: root
-    group: root
-    mode: 0750
+- name: Stage TPV configs (copy)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ tpv_mutable_dir }}/{{ item | basename }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: not item.endswith(".j2")
 
-- name: Execute TPV lint-and-copy-script
+- name: Stage TPV configs (template)
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ tpv_mutable_dir }}/{{ item | basename | splitext | first }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: item.endswith(".j2")
+
+- name: Verify that TPV configs appear in Galaxy job configuration
+  ansible.builtin.lineinfile:
+    path: "{{ galaxy_job_config_file }}"
+    regexp: '^(\s+-\s*["'']?{{ tpv_config_dir }}/{{ item.endswith(".j2") | ternary(item | basename | splitext | first, item | basename) }}["'']?\s*)$'
+    state: absent
+  check_mode: true
+  diff: false
+  loop: "{{ tpv_configs }}"
+  register: __tpv_config_is_configured
+  changed_when: false
+  failed_when: not __tpv_config_is_configured.found
+
+- name: Run TPV lint
   ansible.builtin.command:
-    cmd: "{{ tpv_mutable_dir }}/tpv-lint-and-copy.sh"
+    cmd: "{{ galaxy_venv_dir }}/bin/tpv lint {{ tpv_mutable_dir }}/{{ item.endswith('.j2') | ternary(item | basename | splitext | first, item | basename) }}"
+  environment:
+    PYTHONPATH: "{{ galaxy_server_dir }}/lib"
+  loop: "{{ tpv_configs }}"
+  changed_when: false
+
+- name: Create TPV config dir
+  ansible.builtin.file:
+    state: directory
+    path: "{{ tpv_config_dir }}"
+    mode: 0755
+
+- name: Deploy TPV configs (copy)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ tpv_config_dir }}/{{ item | basename }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: not item.endswith(".j2")
+
+- name: Stage TPV configs (template)
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ tpv_config_dir }}/{{ item | basename | splitext | first }}"
+    # TODO: privsep
+  loop: "{{ tpv_configs }}"
+  when: item.endswith(".j2")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,94 @@
   loop: "{{ tpv_configs }}"
   changed_when: false
 
+- name: TPV dry-run
+  when: tpv_dry_run
+  block:
+    # Mode: new tools only — compare local configs against what is deployed
+    - name: Read deployed TPV config files
+      ansible.builtin.slurp:
+        src: "{{ tpv_config_dir }}/{{ _tpv_fname }}"
+      vars:
+        _tpv_fname: "{{ item.endswith('.j2') | ternary(item | basename | splitext | first, item | basename) }}"
+      loop: "{{ tpv_configs }}"
+      register: __tpv_deployed_configs
+      failed_when: false
+      when: not tpv_dry_run_all_tools
+
+    - name: Collect new TPV tool IDs for dry-run
+      ansible.builtin.set_fact:
+        __tpv_dry_run_tools: >-
+          {{
+            (__tpv_dry_run_tools | default([]))
+            + ((_local.tools | default({}) | list)
+               | difference(_deployed.tools | default({}) | list))
+          }}
+      vars:
+        _local: "{{ (lookup('template', _tpv_pair[0]) if _tpv_pair[0].endswith('.j2') else lookup('file', _tpv_pair[0])) | from_yaml }}"
+        _deployed: "{{ (_tpv_pair[1].content | b64decode | from_yaml) if _tpv_pair[1].content is defined else {} }}"
+      loop: "{{ tpv_configs | zip(__tpv_deployed_configs.results) | list }}"
+      loop_control:
+        loop_var: _tpv_pair
+      when: not tpv_dry_run_all_tools
+
+    # Mode: all tools — gather every non-abstract tool from local and remote configs
+    - name: Collect all TPV tool IDs from local configs for dry-run
+      ansible.builtin.set_fact:
+        __tpv_dry_run_tools: >-
+          {{
+            (__tpv_dry_run_tools | default([]))
+            + (_local.tools | default({}) | dict2items
+               | rejectattr('value.abstract', 'defined')
+               | map(attribute='key') | list)
+          }}
+      vars:
+        _local: "{{ (lookup('template', item) if item.endswith('.j2') else lookup('file', item)) | from_yaml }}"
+      loop: "{{ tpv_configs }}"
+      when: tpv_dry_run_all_tools
+
+    - name: Collect all TPV tool IDs from remote configs for dry-run
+      ansible.builtin.set_fact:
+        __tpv_dry_run_tools: >-
+          {{
+            (__tpv_dry_run_tools | default([]))
+            + ((lookup('url', item) | from_yaml).tools | default({}) | dict2items
+               | rejectattr('value.abstract', 'defined')
+               | map(attribute='key') | list)
+          }}
+      loop: "{{ tpv_dry_run_remote_configs }}"
+      when: tpv_dry_run_all_tools
+
+    - name: Write temporary job_conf.yml for TPV dry-run
+      ansible.builtin.tempfile:
+        suffix: _job_conf.yml
+      register: __tpv_dry_run_job_conf_tmp
+
+    - name: Populate temporary job_conf.yml for TPV dry-run
+      ansible.builtin.copy:
+        content: "{{ galaxy_job_config | to_nice_yaml }}"
+        dest: "{{ __tpv_dry_run_job_conf_tmp.path }}"
+
+    - name: Run TPV dry-run
+      ansible.builtin.command:
+        cmd: >-
+          {{ galaxy_venv_dir }}/bin/tpv dry-run
+          --job-conf {{ __tpv_dry_run_job_conf_tmp.path }}
+          --tool {{ tpv_tool }}
+          {{ ('--user ' + tpv_dry_run_user) if tpv_dry_run_user else '' }}
+      environment:
+        PYTHONPATH: "{{ galaxy_server_dir }}/lib"
+      loop: "{{ __tpv_dry_run_tools | default([]) | unique }}"
+      loop_control:
+        loop_var: tpv_tool
+      changed_when: false
+
+  always:
+    - name: Remove temporary job_conf.yml
+      ansible.builtin.file:
+        path: "{{ __tpv_dry_run_job_conf_tmp.path }}"
+        state: absent
+      when: __tpv_dry_run_job_conf_tmp is defined
+
 - name: Create TPV config dir
   ansible.builtin.file:
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,6 +122,7 @@
       loop_control:
         loop_var: tpv_tool
       changed_when: false
+      ignore_errors: "{{ tpv_dry_run_ignore_errors }}"
 
   always:
     - name: Remove temporary job_conf.yml


### PR DESCRIPTION
  Adds optional tpv dry-run validation before TPV configs are deployed, aborting if any tool fails to map to a destination.

  New variables

- tpv_dry_run (default: false): Enable dry-run 
- tpv_dry_run_all_tools (default: false): When false, only runs dry-run for tools that are new compared to the currently deployed config. When true, runs for every non-abstract tool in all configs
- tpv_dry_run_remote_configs (default: = [] ): Remote TPV config URLs (e.g. tpv-shared-database) to include when tpv_dry_run_all_tools: true
- tpv_dry_run_user (default: ""): User email to pass to tpv dry-run, required if your config has a requires_login rule

  Notes

  - galaxy_job_config (the job config dict) is required when tpv_dry_run: true. It is written to a temp file for the dry-run because tpv dry-run --job-conf expects a standalone file with runners: at the root — this handles setups where the job config is embedded in galaxy.yml rather than a separate file.
  - Requires changes that are currently on the main branch of TPV (recent commits adds tool_type to the mock Tool class). Until that version is released which should be soon, we can upgrade TPV from git main: pip install git+https://github.com/galaxyproject/total-perspective-vortex.git@main.